### PR TITLE
Do not use Set(keys) in indexesWithKeys

### DIFF
--- a/Sources/YapDatabaseExtensions.swift
+++ b/Sources/YapDatabaseExtensions.swift
@@ -233,7 +233,7 @@ extension Persistable {
         Keys>(_ keys: Keys) -> [YapDB.Index] where
         Keys: Sequence,
         Keys.Iterator.Element == String {
-            return Set(keys).map { YapDB.Index(collection: collection, key: $0) }
+            return keys.map { YapDB.Index(collection: collection, key: $0) }
     }
 
     /**

--- a/Tests/YapDatabaseExtensionsTests.swift
+++ b/Tests/YapDatabaseExtensionsTests.swift
@@ -48,7 +48,7 @@ class PersistableTests: XCTestCase {
     func test__indexes_from_keys() {
         let keys = [ "beatle-1", "beatle-2", "beatle-3", "beatle-4", "beatle-2" ]
         let indexes = Person.indexesWithKeys(keys)
-        XCTAssertEqual(indexes.count, 4)
+        XCTAssertEqual(indexes.count, 5)
     }
 }
 


### PR DESCRIPTION
The order of the output should be the same as the order of the input, but using `Set(keys)` destroys the original order of the input.

If removing duplicates is a concern this should be done by the caller prior to calling `indexesWithKeys`. This method is called all over the place and those places expect the order of their output to correspond to the order of their input.

I ran the 618 tests and they passed.