### PR TITLE
Make YapItem properties public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.2
+1. Made `YapItem` properties `public`.
+
 # 4.0.1
 1. Fixed typo in podspec
 

--- a/RCSYapDatabaseExtensions.podspec
+++ b/RCSYapDatabaseExtensions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "RCSYapDatabaseExtensions"
-  s.version           = "4.0.1"
+  s.version           = "4.0.2"
   s.summary           = "Helpers for using value types with YapDatabase."
   s.description       = <<-DESC
 

--- a/Sources/YapDatabaseExtensions.swift
+++ b/Sources/YapDatabaseExtensions.swift
@@ -152,10 +152,10 @@ Used when values and metadatas are read or written together.
 public struct YapItem<Value, Metadata> {
 
     /// The item's value
-    let value: Value
+    public let value: Value
 
     /// The item's metadata
-    let metadata: Metadata?
+    public let metadata: Metadata?
 
     /**
     Create a new YapItem value.


### PR DESCRIPTION
The `value` and `metadata` properties were not explicitly `public` so they defaulted to `internal`.